### PR TITLE
{go.mod,go.sum,main}: Adding initial scaffolding project.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module graphql-go/compatibility-unit-tests
+
+go 1.22.2

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module graphql-go/compatibility-unit-tests
 
 go 1.22.2
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.8.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+  "fmt"
+  "strings"
+
+  "github.com/spf13/cobra"
+)
+
+func main() {
+  compatibility := &cobra.Command{
+    Use:   "compatibility",
+    Short: "Check compatibility validation against the GraphQL standard reference implementation.",
+    Long: `This command allows you to compare a GraphQL implementation against the official reference implementation.`,
+    Args: cobra.MinimumNArgs(1),
+    Run: func(cmd *cobra.Command, args []string) {
+      fmt.Println("Print: " + strings.Join(args, " "))
+    },
+  }
+
+  var rootCmd = &cobra.Command{Use: "app"}
+  rootCmd.AddCommand(compatibility)
+  rootCmd.Execute()
+}


### PR DESCRIPTION
#### Details

- `{go.mod,go.sum,main}`: Adds initial scaffolding of the compatibility cmd.
- `go.mod`: adds initial go's scaffolding.

#### Test Plan

:heavy_check_mark: Tested that the `go run main.go` command is working as expected:

```
$ go run main.go
Usage:
  app [command]

Available Commands:
  compatibility Check compatibility validation against the GraphQL standard reference implementation.
  completion    Generate the autocompletion script for the specified shell
  help          Help about any command

Flags:
  -h, --help   help for app

Use "app [command] --help" for more information about a command.
```

:heavy_check_mark: Tested that the `compatibility` command works as expected:

```
$ go run main.go compatibility test
Print: test
```

