### PR TITLE
{main,cmd,bubbletea}: pkg & files clean-up.

### DIFF
--- a/bubbletea/bubbletea.go
+++ b/bubbletea/bubbletea.go
@@ -1,0 +1,94 @@
+package bubbletea
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type BubbleTea struct {
+	cursor  int
+	choice  string
+	choices []string
+}
+
+func (b BubbleTea) Init() tea.Cmd {
+	return nil
+}
+
+func (b BubbleTea) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q", "esc":
+			return b, tea.Quit
+
+		case "enter":
+			b.choice = b.choices[b.cursor]
+			return b, tea.Quit
+
+		case "down", "j":
+			b.cursor++
+			if b.cursor >= len(b.choices) {
+				b.cursor = 0
+			}
+
+		case "up", "k":
+			b.cursor--
+			if b.cursor < 0 {
+				b.cursor = len(b.choices) - 1
+			}
+		}
+	}
+
+	return b, nil
+}
+
+func (b BubbleTea) View() string {
+	s := strings.Builder{}
+	s.WriteString("")
+
+	for i := 0; i < len(b.choices); i++ {
+		if b.cursor == i {
+			s.WriteString("(•) ")
+		} else {
+			s.WriteString("( ) ")
+		}
+		s.WriteString(b.choices[i])
+		s.WriteString("\n")
+	}
+	s.WriteString("\n(press q to quit)\n")
+
+	return s.String()
+}
+
+type RunResult struct {
+	Choice string
+}
+
+type BubbleTeaParams struct {
+	Choices []string
+}
+
+func NewBubbleTea(p *BubbleTeaParams) *BubbleTea {
+	return &BubbleTea{
+		choices: p.Choices,
+	}
+}
+
+func (b *BubbleTea) Run() (*RunResult, error) {
+	teaProgram := tea.NewProgram(b)
+
+	m, err := teaProgram.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	result := &RunResult{}
+
+	if m, ok := m.(BubbleTea); ok && m.choice != "" {
+		result.Choice = m.choice
+	}
+
+	return result, nil
+}

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -1,68 +1,13 @@
 package cmd
 
 import (
-	"strings"
-
-	tea "github.com/charmbracelet/bubbletea"
+	"graphql-go/compatibility-unit-tests/bubbletea"
 )
 
 type CLI struct {
 }
 
 type model struct {
-	cursor  int
-	choice  string
-	choices map[string]string
-}
-
-func (m model) Init() tea.Cmd {
-	return nil
-}
-
-func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "ctrl+c", "q", "esc":
-			return m, tea.Quit
-
-		case "enter":
-			m.choice = m.choices[m.cursor]
-			return m, tea.Quit
-
-		case "down", "j":
-			m.cursor++
-			if m.cursor >= len(m.choices) {
-				m.cursor = 0
-			}
-
-		case "up", "k":
-			m.cursor--
-			if m.cursor < 0 {
-				m.cursor = len(m.choices) - 1
-			}
-		}
-	}
-
-	return m, nil
-}
-
-func (m model) View() string {
-	s := strings.Builder{}
-	s.WriteString("")
-
-	for i := 0; i < len(m.choices); i++ {
-		if m.cursor == i {
-			s.WriteString("(•) ")
-		} else {
-			s.WriteString("( ) ")
-		}
-		s.WriteString(m.choices[i])
-		s.WriteString("\n")
-	}
-	s.WriteString("\n(press q to quit)\n")
-
-	return s.String()
 }
 
 type RunResult struct {
@@ -70,24 +15,20 @@ type RunResult struct {
 }
 
 type RunParams struct {
-	Choices map[string]string
+	Choices []string
 }
 
 func (c *CLI) Run(p *RunParams) (*RunResult, error) {
-	teaProgram := tea.NewProgram(model{
-		choices: p.Choices,
+	bt := bubbletea.NewBubbleTea(&bubbletea.BubbleTeaParams{
+		Choices: p.Choices,
 	})
 
-	m, err := teaProgram.Run()
+	btRunResult, err := bt.Run()
 	if err != nil {
 		return nil, err
 	}
 
-	result := &RunResult{}
-
-	if m, ok := m.(model); ok && m.choice != "" {
-		result.Choice = m.choice
-	}
-
-	return result, nil
+	return &RunResult{
+		Choice: btRunResult.Choice,
+	}, nil
 }

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type CLI struct {
+}
+
+type model struct {
+	cursor  int
+	choice  string
+	choices map[string]string
+}
+
+func (m model) Init() tea.Cmd {
+	return nil
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q", "esc":
+			return m, tea.Quit
+
+		case "enter":
+			m.choice = m.choices[m.cursor]
+			return m, tea.Quit
+
+		case "down", "j":
+			m.cursor++
+			if m.cursor >= len(m.choices) {
+				m.cursor = 0
+			}
+
+		case "up", "k":
+			m.cursor--
+			if m.cursor < 0 {
+				m.cursor = len(m.choices) - 1
+			}
+		}
+	}
+
+	return m, nil
+}
+
+func (m model) View() string {
+	s := strings.Builder{}
+	s.WriteString("")
+
+	for i := 0; i < len(m.choices); i++ {
+		if m.cursor == i {
+			s.WriteString("(•) ")
+		} else {
+			s.WriteString("( ) ")
+		}
+		s.WriteString(m.choices[i])
+		s.WriteString("\n")
+	}
+	s.WriteString("\n(press q to quit)\n")
+
+	return s.String()
+}
+
+type RunResult struct {
+	Choice string
+}
+
+type RunParams struct {
+	Choices map[string]string
+}
+
+func (c *CLI) Run(p *RunParams) (*RunResult, error) {
+	teaProgram := tea.NewProgram(model{
+		choices: p.Choices,
+	})
+
+	m, err := teaProgram.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	result := &RunResult{}
+
+	if m, ok := m.(model); ok && m.choice != "" {
+		result.Choice = m.choice
+	}
+
+	return result, nil
+}

--- a/main.go
+++ b/main.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"fmt"
 	"log"
-	"os"
-	"strings"
 
-	tea "github.com/charmbracelet/bubbletea"
+	"graphql-go/compatibility-unit-tests/cmd"
 	"graphql-go/compatibility-unit-tests/implementation"
 	"graphql-go/compatibility-unit-tests/puller"
 )
@@ -19,79 +16,19 @@ func init() {
 	}
 }
 
-type model struct {
-	cursor int
-	choice string
-}
-
-func (m model) Init() tea.Cmd {
-	return nil
-}
-
-func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "ctrl+c", "q", "esc":
-			return m, tea.Quit
-
-		case "enter":
-			m.choice = choices[m.cursor]
-			return m, tea.Quit
-
-		case "down", "j":
-			m.cursor++
-			if m.cursor >= len(choices) {
-				m.cursor = 0
-			}
-
-		case "up", "k":
-			m.cursor--
-			if m.cursor < 0 {
-				m.cursor = len(choices) - 1
-			}
-		}
-	}
-
-	return m, nil
-}
-
-func (m model) View() string {
-	s := strings.Builder{}
-	s.WriteString("")
-
-	for i := 0; i < len(choices); i++ {
-		if m.cursor == i {
-			s.WriteString("(•) ")
-		} else {
-			s.WriteString("( ) ")
-		}
-		s.WriteString(choices[i])
-		s.WriteString("\n")
-	}
-	s.WriteString("\n(press q to quit)\n")
-
-	return s.String()
-}
-
 func main() {
-	teaProgram := tea.NewProgram(model{})
+	cli := cmd.CLI{}
 
-	m, err := teaProgram.Run()
+	cliResult, err := cli.Run(&cmd.RunParams{
+		Choices: implementation.Implementations,
+	})
 	if err != nil {
-		os.Exit(1)
-	}
-
-	choice := ""
-
-	if m, ok := m.(model); ok && m.choice != "" {
-		fmt.Printf("\n---\nYou chose %s!\n", m.choice)
-		choice = m.choice
+		log.Fatal(err)
 	}
 
 	p := puller.Puller{}
 	result, err := p.Pull(&puller.PullerParams{
-		RepoURL: choice,
+		RepoURL: cliResult.Choice,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func main() {
 	cli := cmd.CLI{}
 
 	cliResult, err := cli.Run(&cmd.RunParams{
-		Choices: implementation.Implementations,
+		Choices: choices,
 	})
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
#### Details
- `main`: syncs cli pkg.
- `cmd`: wires bubbletea pkg.
- `bubbletea`: adds bubbletea pkg.
- `main`: wires cmd pkg.
- `cmd`: refactors bubble-tea related code to its own file.


#### Test Plan

:heavy_check_mark: Tested that `./bin/start.sh` works as expected:

```
$ ./bin/start.sh
(•) https://github.com/graphql-go/graphql

(press q to quit)
Enumerating objects: 5158, done.
Counting objects: 100% (96/96), done.
Compressing objects: 100% (58/58), done.
Total 5158 (delta 52), reused 52 (delta 34), pack-reused 5062 (from 3)
2025/02/07 17:29:17 result: &{}
```