### PR TITLE
{main,app}: adds app pkg.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,0 +1,23 @@
+package app
+
+import (
+	"graphql-go/compatibility-unit-tests/puller"
+)
+
+type App struct {
+}
+
+type AppResult struct {
+}
+
+func (app *App) Run(repoURL string) (*AppResult, error) {
+	p := puller.Puller{}
+
+	if _, err := p.Pull(&puller.PullerParams{
+		RepoURL: repoURL,
+	}); err != nil {
+		return nil, err
+	}
+
+	return &AppResult{}, nil
+}

--- a/main.go
+++ b/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"log"
 
+	mainApp "graphql-go/compatibility-unit-tests/app"
 	"graphql-go/compatibility-unit-tests/cmd"
 	"graphql-go/compatibility-unit-tests/implementation"
-	"graphql-go/compatibility-unit-tests/puller"
 )
 
 var choices = []string{}
@@ -26,10 +26,8 @@ func main() {
 		log.Fatal(err)
 	}
 
-	p := puller.Puller{}
-	result, err := p.Pull(&puller.PullerParams{
-		RepoURL: cliResult.Choice,
-	})
+	app := mainApp.App{}
+	result, err := app.Run(cliResult.Choice)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
#### Details
- `main`: wires app to main.
- `app`: adds app implementation.

#### Test Plan

:heavy_check_mark: Tested that `./bin/start.sh` works as expected:

```
$ ./bin/start.sh 
(•) https://github.com/graphql-go/graphql

(press q to quit)
Enumerating objects: 5158, done.
Counting objects: 100% (96/96), done.
Compressing objects: 100% (58/58), done.
Total 5158 (delta 52), reused 52 (delta 34), pack-reused 5062 (from 3)
2025/02/10 14:05:27 result: &{}
````