### PR TITLE
{main,puller,app,implementation,types}: adds support for cloning reference implementation

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"graphql-go/compatibility-unit-tests/puller"
+	"graphql-go/compatibility-unit-tests/types"
 )
 
 type App struct {
@@ -10,11 +11,17 @@ type App struct {
 type AppResult struct {
 }
 
-func (app *App) Run(repoURL string) (*AppResult, error) {
+type AppParams struct {
+	Implementation    types.Implementation
+	RefImplementation types.Implementation
+}
+
+func (app *App) Run(params AppParams) (*AppResult, error) {
 	p := puller.Puller{}
 
 	if _, err := p.Pull(&puller.PullerParams{
-		RepoURL: repoURL,
+		Implementation:    params.Implementation,
+		RefImplementation: params.RefImplementation,
 	}); err != nil {
 		return nil, err
 	}

--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -1,7 +1,31 @@
 package implementation
 
-var Implementations = map[string]string{
-	"https://github.com/graphql-go/graphql": "https://github.com/graphql-go/graphql",
+import (
+	"graphql-go/compatibility-unit-tests/types"
+)
+
+var GraphqlGoImplementation = types.Implementation{
+	Repo: types.Repository{
+		Name:          "graphql-go-graphql",
+		URL:           "https://github.com/graphql-go/graphql",
+		ReferenceName: "refs/heads/master",
+	},
 }
 
-var JSRefImplementation string = "https://github.com/graphql/graphql-js"
+var GraphqlJSImplementation = types.Implementation{
+	Repo: types.Repository{
+		Name:          "graphql-graphql-js",
+		URL:           "https://github.com/graphql/graphql-js",
+		ReferenceName: "v0.6.0",
+	},
+}
+
+var Implementations = []types.Implementation{GraphqlGoImplementation}
+
+var gqlGoImplURL = GraphqlGoImplementation.Repo.URL
+var jsImplURL = GraphqlJSImplementation.Repo.URL
+
+var ImplementationsMap = map[string]types.Implementation{
+	gqlGoImplURL: GraphqlGoImplementation,
+	jsImplURL:    GraphqlJSImplementation,
+}

--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -4,4 +4,4 @@ var Implementations = map[string]string{
 	"https://github.com/graphql-go/graphql": "https://github.com/graphql-go/graphql",
 }
 
-var JSRefImplementation string = "https://github.com/graphql/graphql-js/tree/v0.6.0"
+var JSRefImplementation string = "https://github.com/graphql/graphql-js"

--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -3,3 +3,5 @@ package implementation
 var Implementations = map[string]string{
 	"https://github.com/graphql-go/graphql": "https://github.com/graphql-go/graphql",
 }
+
+var JSRefImplementation string = "https://github.com/graphql/graphql-js/tree/v0.6.0"

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	mainApp "graphql-go/compatibility-unit-tests/app"
 	"graphql-go/compatibility-unit-tests/cmd"
 	"graphql-go/compatibility-unit-tests/implementation"
+	"graphql-go/compatibility-unit-tests/types"
 )
 
 var choices = []string{}
@@ -27,7 +28,18 @@ func main() {
 	}
 
 	app := mainApp.App{}
-	result, err := app.Run(cliResult.Choice)
+	result, err := app.Run(mainApp.AppParams{
+		Implementation: types.Implementation{
+			Repo: types.Repository{
+				URL: cliResult.Choice,
+			},
+		},
+		RefImplementation: types.Implementation{
+			Repo: types.Repository{
+				URL: implementation.JSRefImplementation,
+			},
+		},
+	})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -1,19 +1,19 @@
 package main
 
 import (
+	"fmt"
 	"log"
 
 	mainApp "graphql-go/compatibility-unit-tests/app"
 	"graphql-go/compatibility-unit-tests/cmd"
 	"graphql-go/compatibility-unit-tests/implementation"
-	"graphql-go/compatibility-unit-tests/types"
 )
 
 var choices = []string{}
 
 func init() {
-	for i := range implementation.Implementations {
-		choices = append(choices, i)
+	for _, i := range implementation.Implementations {
+		choices = append(choices, i.Repo.URL)
 	}
 }
 
@@ -27,20 +27,15 @@ func main() {
 		log.Fatal(err)
 	}
 
+	currentImplementation, ok := implementation.ImplementationsMap[cliResult.Choice]
+	if !ok {
+		log.Fatal(fmt.Errorf("expected to find the following implementation: %v", cliResult.Choice))
+	}
+
 	app := mainApp.App{}
 	result, err := app.Run(mainApp.AppParams{
-		Implementation: types.Implementation{
-			Repo: types.Repository{
-				Name: "implementation",
-				URL:  cliResult.Choice,
-			},
-		},
-		RefImplementation: types.Implementation{
-			Repo: types.Repository{
-				Name: "reference-implementation",
-				URL:  implementation.JSRefImplementation,
-			},
-		},
+		Implementation:    currentImplementation,
+		RefImplementation: implementation.GraphqlJSImplementation,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -31,12 +31,14 @@ func main() {
 	result, err := app.Run(mainApp.AppParams{
 		Implementation: types.Implementation{
 			Repo: types.Repository{
-				URL: cliResult.Choice,
+				Name: "implementation",
+				URL:  cliResult.Choice,
 			},
 		},
 		RefImplementation: types.Implementation{
 			Repo: types.Repository{
-				URL: implementation.JSRefImplementation,
+				Name: "reference-implementation",
+				URL:  implementation.JSRefImplementation,
 			},
 		},
 	})

--- a/puller/puller.go
+++ b/puller/puller.go
@@ -4,6 +4,8 @@ import (
 	"os"
 
 	"github.com/go-git/go-git/v5"
+
+	"graphql-go/compatibility-unit-tests/types"
 )
 
 type Puller struct {
@@ -13,15 +15,23 @@ type PullerResult struct {
 }
 
 type PullerParams struct {
-	RepoURL string
+	Implementation    types.Implementation
+	RefImplementation types.Implementation
 }
 
 func (p *Puller) Pull(params *PullerParams) (*PullerResult, error) {
-	if _, err := git.PlainClone("./repos", false, &git.CloneOptions{
-		URL:      params.RepoURL,
-		Progress: os.Stdout,
-	}); err != nil {
-		return nil, err
+	repos := []types.Implementation{
+		params.Implementation,
+		params.RefImplementation,
+	}
+
+	for _, r := range repos {
+		if _, err := git.PlainClone("./repos", false, &git.CloneOptions{
+			URL:      r.Repo.URL,
+			Progress: os.Stdout,
+		}); err != nil {
+			return nil, err
+		}
 	}
 
 	return &PullerResult{}, nil

--- a/puller/puller.go
+++ b/puller/puller.go
@@ -26,7 +26,13 @@ func (p *Puller) Pull(params *PullerParams) (*PullerResult, error) {
 	}
 
 	for _, r := range repos {
-		if _, err := git.PlainClone("./repos", false, &git.CloneOptions{
+		name := "./repos/" + r.Repo.Name
+		if _, err := os.Stat(name); os.IsNotExist(err) {
+			if err := os.Mkdir(name, os.ModePerm); err != nil {
+				return nil, err
+			}
+		}
+		if _, err := git.PlainClone(name, false, &git.CloneOptions{
 			URL:      r.Repo.URL,
 			Progress: os.Stdout,
 		}); err != nil {

--- a/types/types.go
+++ b/types/types.go
@@ -1,7 +1,8 @@
 package types
 
 type Repository struct {
-	URL string
+	Name string
+	URL  string
 }
 
 type Implementation struct {

--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,9 @@
+package types
+
+type Repository struct {
+	URL string
+}
+
+type Implementation struct {
+	Repo Repository
+}

--- a/types/types.go
+++ b/types/types.go
@@ -1,8 +1,9 @@
 package types
 
 type Repository struct {
-	Name string
-	URL  string
+	Name          string
+	URL           string
+	ReferenceName string
 }
 
 type Implementation struct {


### PR DESCRIPTION
#### Details
- `main`: wires implementations fixed structs.
- `types`: wires ReferenceName type.
- `implementation`: consolidates Implementations using structs.
- `main`: wires repo names.
- `implementation`: support for graphql-js implementation versions, eg. `0.6.0`.
- `puller`: wires repo name dir creation.
- `types`: adds Repository.Name field.
- `main`: wires implementations to main.
- `puller`: wires implementations.
- `app`: wires types to App struct.
- `implementation`: adds js ref implementation.
- `types`: adds types structs.

#### Test Plan

:heavy_check_mark: Tested that `./bin/start.sh` works as expected:


```
$ ./bin/start.sh 
(•) https://github.com/graphql-go/graphql

(press q to quit)
Enumerating objects: 5158, done.
Counting objects: 100% (98/98), done.
Compressing objects: 100% (59/59), done.
Total 5158 (delta 54), reused 53 (delta 35), pack-reused 5060 (from 3)
Enumerating objects: 51293, done.
Counting objects: 100% (16/16), done.
Compressing objects: 100% (16/16), done.
Total 51293 (delta 0), reused 1 (delta 0), pack-reused 51277 (from 1)
2025/02/10 17:48:52 result: &{}
```


