### PR TITLE
{extractor}: wires ref implementation files tests to extractor.

### DIFF
--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -2,6 +2,7 @@ package extractor
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/tdewolff/parse/v2"
 	"github.com/tdewolff/parse/v2/js"
@@ -17,7 +18,24 @@ type ExtractorParams struct {
 	Source string
 }
 
+func (e *Extractor) readFiles() (*ExtractorResult, error) {
+	entries, err := os.ReadDir("./repos/graphql-graphql-js")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, e := range entries {
+		fmt.Println(e.Name())
+	}
+
+	return nil, nil
+}
+
 func (e *Extractor) Extract(params *ExtractorParams) (*ExtractorResult, error) {
+	if _, err := e.readFiles(); err != nil {
+		return nil, err
+	}
+
 	ast, err := js.Parse(parse.NewInputString(params.Source), js.Options{})
 	if err != nil {
 		return nil, err

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -3,6 +3,7 @@ package extractor
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/tdewolff/parse/v2"
 	"github.com/tdewolff/parse/v2/js"
@@ -25,7 +26,7 @@ func (e *Extractor) readFiles() (*ExtractorResult, error) {
 	}
 
 	for _, e := range entries {
-		fmt.Println(e.Name())
+		fmt.Println(strings.HasPrefix(e.Name(), "-test.ts"))
 	}
 
 	return nil, nil


### PR DESCRIPTION
#### Details 
- `extractor`: adds filter of files by test name.
- `extractor`: wires reading impl files.
- `extractor`: wires filter of tests files.

#### Test Plan
```
$ ./bin/start.sh 
(•) https://github.com/graphql-go/graphql

(press q to quit)
Enumerating objects: 5158, done.
Counting objects: 100% (98/98), done.
Compressing objects: 100% (59/59), done.
Total 5158 (delta 54), reused 53 (delta 35), pack-reused 5060 (from 3)
Enumerating objects: 51418, done.
Counting objects: 100% (41/41), done.
Compressing objects: 100% (30/30), done.
Total 51418 (delta 16), reused 18 (delta 7), pack-reused 51377 (from 2)
2025/02/17 17:52:56 result: &{}
```