### PR TITLE
puller-js: extracts all the tests names into `unit-tests.txt` file.

### DIFF
--- a/puller-js/index.ts
+++ b/puller-js/index.ts
@@ -4,17 +4,75 @@ import { camelCase, upperFirst } from "lodash";
 import * as fs from "fs";
 
 const fileName = "schema-test.ts";
-const sourceFile = ts.createSourceFile(
-  fileName,
-  readFileSync(fileName).toString(),
-  ts.ScriptTarget.ES2015,
-);
+
+class TestFiles {
+  constructor() {}
+
+  extractor() {
+    const files = [] as any;
+    const rootDir = "../repos/graphql-graphql-js";
+    const walkDir = (dirName: any) => {
+      const dirNames = fs.readdirSync(dirName, { withFileTypes: true });
+
+      for (let i = 0; i < dirNames.length; i++) {
+        const item = dirNames[i];
+        const filePath = `${item.path}/${item.name}`;
+
+        if (item.name.startsWith(".")) {
+          continue;
+        }
+
+        if (!fs.existsSync(filePath)) {
+          continue;
+        }
+
+        if (item.isDirectory()) {
+          walkDir(filePath);
+          continue;
+        }
+
+        files.push(filePath);
+      }
+    };
+
+    walkDir(rootDir);
+
+    return files;
+  }
+}
+
+const tests = [] as any;
 
 class TestNames {
   constructor() {}
 
+  extractor(files: string[]) {
+    const result = [];
+
+    for (let i = 0; i < 100; i++) {
+      const fileName0 = files[i];
+      const fileName = "schema-test.ts";
+
+      const check = fileName0.includes("__tests__");
+      if (!check) {
+        continue;
+      }
+
+      const sourceFile = ts.createSourceFile(
+        fileName,
+        readFileSync(fileName).toString(),
+        ts.ScriptTarget.ES2015,
+      );
+
+      const testNames = this.walk(sourceFile);
+
+      result.push(...testNames);
+    }
+
+    return result;
+  }
+
   walk(node: ts.SourceFile | ts.Node) {
-    const tests = [] as any;
     const n = node as any;
 
     if (n?.kind === ts.SyntaxKind.CallExpression) {
@@ -45,39 +103,16 @@ class TestNames {
   }
 }
 
-class TestFiles {
-  constructor() {}
-
-  extractor() {
-    const files = [] as any;
-    const rootDir = "../repos/graphql-graphql-js";
-    const walkDir = (dirName: any) => {
-      const dirNames = fs.readdirSync(dirName, { withFileTypes: true });
-
-      for (let i = 0; i < dirNames.length; i++) {
-        const item = dirNames[i];
-        const filePath = `${item.path}/${item.name}`;
-        if (
-          item.isDirectory() &&
-          fs.existsSync(filePath) &&
-          !item.name.startsWith(".")
-        ) {
-          walkDir(filePath);
-        } else {
-          files.push(filePath);
-        }
-      }
-    };
-
-    walkDir(rootDir);
-
-    return files;
-  }
-}
-
 const testNames = new TestNames();
 const testFiles = new TestFiles();
 
 const testFilesResult = testFiles.extractor();
+const testNamesResult = testNames.extractor(testFilesResult);
 
-console.log(testFilesResult);
+let result = "";
+for (let i = 0; i < testNamesResult.length; i++) {
+  const testName = testNamesResult[i];
+  result += `${testName}\n`;
+}
+
+fs.writeFileSync("unit-tests.txt", result);

--- a/puller-js/index.ts
+++ b/puller-js/index.ts
@@ -10,16 +10,11 @@ const sourceFile = ts.createSourceFile(
   ts.ScriptTarget.ES2015,
 );
 
-const tests = [] as any;
-
-// walk(sourceFile);
-// walkDir(rootDir);
-// console.log(files);
-
 class TestNames {
   constructor() {}
 
   walk(node: ts.SourceFile | ts.Node) {
+    const tests = [] as any;
     const n = node as any;
 
     if (n?.kind === ts.SyntaxKind.CallExpression) {
@@ -39,6 +34,14 @@ class TestNames {
     node.forEachChild((subNode: ts.Node) => {
       this.walk(subNode);
     });
+
+    const result = [];
+    for (let i = 0; i < tests.length; i++) {
+      const testName = upperFirst(camelCase(tests[i]));
+      result.push(testName);
+    }
+
+    return result;
   }
 }
 
@@ -46,11 +49,6 @@ class TestFiles {
   constructor() {}
 
   extractor() {
-    for (let i = 0; i < tests.length; i++) {
-      const testName = upperFirst(camelCase(tests[i]));
-      console.log(testName);
-    }
-
     const files = [] as any;
     const rootDir = "../repos/graphql-graphql-js";
     const walkDir = (dirName: any) => {
@@ -70,5 +68,7 @@ class TestFiles {
         }
       }
     };
+
+    return files;
   }
 }

--- a/puller-js/index.ts
+++ b/puller-js/index.ts
@@ -69,6 +69,15 @@ class TestFiles {
       }
     };
 
+    walkDir(rootDir);
+
     return files;
   }
 }
+
+const testNames = new TestNames();
+const testFiles = new TestFiles();
+
+const testFilesResult = testFiles.extractor();
+
+console.log(testFilesResult);

--- a/puller-js/index.ts
+++ b/puller-js/index.ts
@@ -12,54 +12,63 @@ const sourceFile = ts.createSourceFile(
 
 const tests = [] as any;
 
-function walk(node: ts.SourceFile | ts.Node) {
-  const n = node as any;
+// walk(sourceFile);
+// walkDir(rootDir);
+// console.log(files);
 
-  if (n?.kind === ts.SyntaxKind.CallExpression) {
-    if (n?.arguments && n?.arguments.length) {
-      if (n?.arguments[0].text) {
-        if (
-          n?.expression?.escapedText === "describe" ||
-          n?.expression?.escapedText === "it"
-        ) {
-          const testName = n?.arguments[0].text;
-          tests.push(testName);
+class TestNames {
+  constructor() {}
+
+  walk(node: ts.SourceFile | ts.Node) {
+    const n = node as any;
+
+    if (n?.kind === ts.SyntaxKind.CallExpression) {
+      if (n?.arguments && n?.arguments.length) {
+        if (n?.arguments[0].text) {
+          if (
+            n?.expression?.escapedText === "describe" ||
+            n?.expression?.escapedText === "it"
+          ) {
+            const testName = n?.arguments[0].text;
+            tests.push(testName);
+          }
         }
       }
     }
+
+    node.forEachChild((subNode: ts.Node) => {
+      this.walk(subNode);
+    });
   }
-
-  node.forEachChild((subNode: ts.Node) => {
-    walk(subNode);
-  });
 }
 
-// walk(sourceFile);
+class TestFiles {
+  constructor() {}
 
-for (let i = 0; i < tests.length; i++) {
-  const testName = upperFirst(camelCase(tests[i]));
-  console.log(testName);
-}
-
-const files = [] as any;
-const rootDir = "../repos/graphql-graphql-js";
-const walkDir = (dirName: any) => {
-  const dirNames = fs.readdirSync(dirName, { withFileTypes: true });
-
-  for (let i = 0; i < dirNames.length; i++) {
-    const item = dirNames[i];
-    const filePath = `${item.path}/${item.name}`;
-    if (
-      item.isDirectory() &&
-      fs.existsSync(filePath) &&
-      !item.name.startsWith(".")
-    ) {
-      walkDir(filePath);
-    } else {
-      files.push(filePath);
+  extractor() {
+    for (let i = 0; i < tests.length; i++) {
+      const testName = upperFirst(camelCase(tests[i]));
+      console.log(testName);
     }
-  }
-};
 
-walkDir(rootDir);
-console.log(files);
+    const files = [] as any;
+    const rootDir = "../repos/graphql-graphql-js";
+    const walkDir = (dirName: any) => {
+      const dirNames = fs.readdirSync(dirName, { withFileTypes: true });
+
+      for (let i = 0; i < dirNames.length; i++) {
+        const item = dirNames[i];
+        const filePath = `${item.path}/${item.name}`;
+        if (
+          item.isDirectory() &&
+          fs.existsSync(filePath) &&
+          !item.name.startsWith(".")
+        ) {
+          walkDir(filePath);
+        } else {
+          files.push(filePath);
+        }
+      }
+    };
+  }
+}

--- a/puller-js/index.ts
+++ b/puller-js/index.ts
@@ -49,11 +49,10 @@ class TestNames {
   extractor(files: string[]) {
     const result = [];
 
-    for (let i = 0; i < 100; i++) {
-      const fileName0 = files[i];
-      const fileName = "schema-test.ts";
+    for (let i = 0; i < files.length; i++) {
+      const fileName = files[i];
 
-      const check = fileName0.includes("__tests__");
+      const check = fileName.includes("__tests__");
       if (!check) {
         continue;
       }


### PR DESCRIPTION
#### Details
- `index`: consolidates TestNames implementation.
- `puller-js`: consolidates TestFiles & TestNames implementation.
- `index`: implements TestNames & TestFiles instances.

#### Test Plan
:heavy_check_mark:  Tested that `puller-js` extracts all tests names from `graphql-js` implementation into `unit-tests.txt` file.

```
$ cat unit-tests.txt | head -n 10
DedentString
RemovesIndentationInTypicalUsage
RemovesOnlyTheFirstLevelOfIndentation
DoesNotEscapeSpecialCharacters
AlsoRemovesIndentationUsingTabs
RemovesLeadingAndTrailingNewlines
RemovesAllTrailingSpacesAndTabs
WorksOnTextWithoutLeadingNewline
Dedent
RemovesIndentationInTypicalUsage
...
```