### PR TITLE
validator: adds working implementation

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"fmt"
+
 	"graphql-go/compatibility-unit-tests/extractor"
 	"graphql-go/compatibility-unit-tests/puller"
 	"graphql-go/compatibility-unit-tests/types"
@@ -31,17 +33,28 @@ func (app *App) Run(params AppParams) (*AppResult, error) {
 	}
 
 	ex := extractor.Extractor{}
-	if _, err := ex.Extract(&extractor.ExtractorParams{
+	extractorResult, err := ex.Extract(&extractor.ExtractorParams{
 		Implementation:    params.Implementation,
 		RefImplementation: params.RefImplementation,
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, err
+	}
+
+	implementationTests, ok := extractorResult.TestNames[types.GoImplementationType]
+	if !ok {
+		return nil, fmt.Errorf("failed to find implementation type with key: %v", types.GoImplementationType)
+	}
+
+	refImplementationTests, ok := extractorResult.TestNames[types.RefImplementationType]
+	if !ok {
+		return nil, fmt.Errorf("failed to find implementation type with key: %v", types.RefImplementationType)
 	}
 
 	val := validator.Validator{}
 	validatorResult, err := val.Validate(&validator.ValidatorParams{
-		ImplementationTests:    []types.ImplementationTest{},
-		RefImplementationTests: []types.ImplementationTest{},
+		ImplementationTests:    implementationTests,
+		RefImplementationTests: refImplementationTests,
 	})
 	if err != nil {
 		return nil, err

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -43,7 +43,7 @@ func (e *Extractor) implementationTestNames(params ImplTestNamesParams) (map[typ
 		switch impl.Type {
 		case types.GoImplementationType:
 			goExtractor := GoExtractor{}
-			testNames, err := goExtractor.TestNames(impl.Repo.Dir)
+			testNames, err := goExtractor.TestNames(impl)
 			if err != nil {
 				return nil, err
 			}

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -2,8 +2,6 @@ package extractor
 
 import (
 	"fmt"
-	"os"
-	"strings"
 
 	"graphql-go/compatibility-unit-tests/types"
 )
@@ -56,7 +54,8 @@ func (e *Extractor) implementationTestNames(params ImplTestNamesParams) (map[typ
 			}
 
 		case types.RefImplementationType:
-			testNames, err := e.refTestNames(impl)
+			refExtractor := RefExtractor{}
+			testNames, err := refExtractor.TestNames(impl)
 			if err != nil {
 				return nil, err
 			}
@@ -72,13 +71,4 @@ func (e *Extractor) implementationTestNames(params ImplTestNamesParams) (map[typ
 	}
 
 	return result, nil
-}
-
-func (e *Extractor) refTestNames(impl types.Implementation) ([]string, error) {
-	f, err := os.ReadFile(impl.TestNamesFilePath)
-	if err != nil {
-		return nil, err
-	}
-
-	return strings.Split(string(f), "\n"), nil
 }

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -2,12 +2,7 @@ package extractor
 
 import (
 	"fmt"
-	"go/ast"
-	"go/parser"
-	"go/token"
-	"io/fs"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"graphql-go/compatibility-unit-tests/types"
@@ -49,7 +44,8 @@ func (e *Extractor) implementationTestNames(params ImplTestNamesParams) (map[typ
 		impl := params.Implementations[i]
 		switch impl.Type {
 		case types.GoImplementationType:
-			testNames, err := e.goTestNames(impl.Repo.Dir)
+			goExtractor := GoExtractor{}
+			testNames, err := goExtractor.TestNames(impl.Repo.Dir)
 			if err != nil {
 				return nil, err
 			}
@@ -76,92 +72,6 @@ func (e *Extractor) implementationTestNames(params ImplTestNamesParams) (map[typ
 	}
 
 	return result, nil
-}
-
-func (e *Extractor) testFiles(rootDir string) ([]string, error) {
-	testFiles := []string{}
-
-	walk := func(s string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if d.IsDir() {
-			return nil
-		}
-
-		if strings.HasSuffix(s, "_test.go") {
-			testFiles = append(testFiles, s)
-		}
-
-		return nil
-	}
-
-	filepath.WalkDir(rootDir, walk)
-
-	return testFiles, nil
-}
-
-func (e *Extractor) readFile(filePath string) (*os.File, error) {
-	goFile, err := os.Open(filePath)
-	if err != nil {
-		return nil, err
-	}
-
-	return goFile, nil
-}
-
-func (e *Extractor) readFuncNames(filePath string) ([]string, error) {
-	goFile, err := e.readFile(filePath)
-	if err != nil {
-		return nil, err
-	}
-	defer goFile.Close()
-
-	funcNames := []string{}
-	fset := token.NewFileSet()
-	astFile, err := parser.ParseFile(fset, "", goFile, parser.ParseComments)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, decl := range astFile.Decls {
-		switch t := decl.(type) {
-		case *ast.FuncDecl:
-			funcNames = append(funcNames, t.Name.Name)
-		}
-	}
-
-	return funcNames, nil
-}
-
-func (e *Extractor) testNames(testFiles []string) ([]string, error) {
-	result := []string{}
-
-	for _, filePath := range testFiles {
-		funcNames, err := e.readFuncNames(filePath)
-		if err != nil {
-			return result, err
-		}
-
-		result = append(result, funcNames...)
-	}
-
-	return result, nil
-}
-
-func (e *Extractor) goTestNames(rootDir string) ([]string, error) {
-	testFiles, err := e.testFiles(rootDir)
-	if err != nil {
-		return nil, err
-	}
-
-	testNames, err := e.testNames(testFiles)
-	if err != nil {
-		return nil, err
-	}
-
-	return testNames, nil
 }
 
 func (e *Extractor) refTestNames(impl types.Implementation) ([]string, error) {

--- a/extractor/go.go
+++ b/extractor/go.go
@@ -1,0 +1,99 @@
+package extractor
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type GoExtractor struct{}
+
+func (e *GoExtractor) TestNames(rootDir string) ([]string, error) {
+	testFiles, err := e.readTestFiles(rootDir)
+	if err != nil {
+		return nil, err
+	}
+
+	testNames, err := e.readTestNames(testFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	return testNames, nil
+}
+
+func (e *GoExtractor) readTestFiles(rootDir string) ([]string, error) {
+	testFiles := []string{}
+
+	walk := func(s string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		if strings.HasSuffix(s, "_test.go") {
+			testFiles = append(testFiles, s)
+		}
+
+		return nil
+	}
+
+	filepath.WalkDir(rootDir, walk)
+
+	return testFiles, nil
+}
+
+func (e *GoExtractor) readTestNames(testFiles []string) ([]string, error) {
+	result := []string{}
+
+	for _, filePath := range testFiles {
+		funcNames, err := e.readFuncNames(filePath)
+		if err != nil {
+			return result, err
+		}
+
+		result = append(result, funcNames...)
+	}
+
+	return result, nil
+}
+
+func (e *GoExtractor) readFuncNames(filePath string) ([]string, error) {
+	goFile, err := e.readFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer goFile.Close()
+
+	funcNames := []string{}
+	fset := token.NewFileSet()
+	astFile, err := parser.ParseFile(fset, "", goFile, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, decl := range astFile.Decls {
+		switch t := decl.(type) {
+		case *ast.FuncDecl:
+			funcNames = append(funcNames, t.Name.Name)
+		}
+	}
+
+	return funcNames, nil
+}
+
+func (e *GoExtractor) readFile(filePath string) (*os.File, error) {
+	goFile, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return goFile, nil
+}

--- a/extractor/go.go
+++ b/extractor/go.go
@@ -8,12 +8,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"graphql-go/compatibility-unit-tests/types"
 )
 
 type GoExtractor struct{}
 
-func (e *GoExtractor) TestNames(rootDir string) ([]string, error) {
-	testFiles, err := e.readTestFiles(rootDir)
+func (e *GoExtractor) TestNames(impl types.Implementation) ([]string, error) {
+	testFiles, err := e.readTestFiles(impl.Repo.Dir)
 	if err != nil {
 		return nil, err
 	}

--- a/extractor/go.go
+++ b/extractor/go.go
@@ -12,6 +12,8 @@ import (
 	"graphql-go/compatibility-unit-tests/types"
 )
 
+const testPrefix string = "Test"
+
 type GoExtractor struct{}
 
 func (e *GoExtractor) TestNames(impl types.Implementation) ([]string, error) {
@@ -20,9 +22,15 @@ func (e *GoExtractor) TestNames(impl types.Implementation) ([]string, error) {
 		return nil, err
 	}
 
-	testNames, err := e.readTestNames(testFiles)
+	tNames, err := e.readTestNames(testFiles)
 	if err != nil {
 		return nil, err
+	}
+
+	testNames := []string{}
+	for _, testName := range tNames {
+		t := strings.TrimPrefix(testName, testPrefix)
+		testNames = append(testNames, t)
 	}
 
 	return testNames, nil

--- a/extractor/ref.go
+++ b/extractor/ref.go
@@ -1,0 +1,19 @@
+package extractor
+
+import (
+	"os"
+	"strings"
+
+	"graphql-go/compatibility-unit-tests/types"
+)
+
+type RefExtractor struct{}
+
+func (e *RefExtractor) TestNames(impl types.Implementation) ([]string, error) {
+	f, err := os.ReadFile(impl.TestNamesFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return strings.Split(string(f), "\n"), nil
+}

--- a/main.go
+++ b/main.go
@@ -41,5 +41,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	log.Printf("result: %+v", result)
+	log.Printf("successful tests count: %+v", len(result.SuccessfulTests))
+	log.Printf("failed tests count: %+v", len(result.FailedTests))
 }

--- a/types/types.go
+++ b/types/types.go
@@ -26,7 +26,9 @@ type ImplementationTest struct {
 }
 
 type SuccessfulTest struct {
+	Name string
 }
 
 type FailedTest struct {
+	Name string
 }

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -1,8 +1,6 @@
 package validator
 
 import (
-	"log"
-
 	"graphql-go/compatibility-unit-tests/types"
 )
 
@@ -20,17 +18,17 @@ type ValidatorResult struct {
 }
 
 func (v *Validator) Validate(params *ValidatorParams) (*ValidatorResult, error) {
-	implementationTests := make(map[string]string, 0)
+	refImplTestsMap := make(map[string]string, 0)
 
 	successfultTests := []types.SuccessfulTest{}
 	failedTests := []types.FailedTest{}
 
 	for _, testName := range params.RefImplementationTests.TestNames {
-		implementationTests[testName] = testName
+		refImplTestsMap[testName] = testName
 	}
 
 	for _, testName := range params.ImplementationTests.TestNames {
-		tName, found := implementationTests[testName]
+		tName, found := refImplTestsMap[testName]
 		if found {
 			successfultTests = append(successfultTests, types.SuccessfulTest{
 				Name: tName,

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -8,8 +8,8 @@ type Validator struct {
 }
 
 type ValidatorParams struct {
-	ImplementationTests    []types.ImplementationTest
-	RefImplementationTests []types.ImplementationTest
+	ImplementationTests    []types.Implementation
+	RefImplementationTests []types.Implementation
 }
 
 type ValidatorResult struct {

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -1,6 +1,8 @@
 package validator
 
 import (
+	"log"
+
 	"graphql-go/compatibility-unit-tests/types"
 )
 
@@ -18,8 +20,30 @@ type ValidatorResult struct {
 }
 
 func (v *Validator) Validate(params *ValidatorParams) (*ValidatorResult, error) {
+	implementationTests := make(map[string]string, 0)
+
+	successfultTests := []types.SuccessfulTest{}
+	failedTests := []types.FailedTest{}
+
+	for _, testName := range params.RefImplementationTests.TestNames {
+		implementationTests[testName] = testName
+	}
+
+	for _, testName := range params.ImplementationTests.TestNames {
+		tName, found := implementationTests[testName]
+		if found {
+			successfultTests = append(successfultTests, types.SuccessfulTest{
+				Name: tName,
+			})
+		} else {
+			failedTests = append(failedTests, types.FailedTest{
+				Name: tName,
+			})
+		}
+	}
+
 	return &ValidatorResult{
-		SuccessfulTests: []types.SuccessfulTest{},
-		FailedTests:     []types.FailedTest{},
+		SuccessfulTests: successfultTests,
+		FailedTests:     failedTests,
 	}, nil
 }

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -8,8 +8,8 @@ type Validator struct {
 }
 
 type ValidatorParams struct {
-	ImplementationTests    []types.Implementation
-	RefImplementationTests []types.Implementation
+	ImplementationTests    types.Implementation
+	RefImplementationTests types.Implementation
 }
 
 type ValidatorResult struct {


### PR DESCRIPTION
#### Details
- `validator`: consolidates Validate implementation.
- `main`: improves result logging.
- `validator`: adds validate implementation.
- `types`: wires Name field to SuccessfulTest & FailedTest structs.
- `extractor`: normalizes test case name.
- `extractor`: consolidates go extractor TestNames method.
- `extractor`: isolates ref extractor code.
- `extractor`: refactors go related extractor code.
- `validator`: syncs ValidatorParams field types.
- `app`: wires validator params.
- `validator`: updates ValidatorParams fields types.

#### Test Plan
:heavy_check_mark:  Tested that validator implementation works as expected:

```
$ ./bin/start.sh 
(•) https://github.com/graphql-go/graphql

(press q to quit)
2025/03/03 15:33:14 successful tests count: 28
2025/03/03 15:33:14 failed tests count: 847
```