### PR TITLE
result: adds result component

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,13 +3,24 @@ package main
 import (
 	"fmt"
 	"log"
+	"strconv"
 
 	mainApp "graphql-go/compatibility-unit-tests/app"
 	"graphql-go/compatibility-unit-tests/cmd"
 	"graphql-go/compatibility-unit-tests/implementation"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 var choices = []string{}
+
+var style = lipgloss.NewStyle().
+	Bold(true).
+	Foreground(lipgloss.Color("#FAFAFA")).
+	Background(lipgloss.Color("#7D56F4")).
+	PaddingTop(2).
+	PaddingLeft(4).
+	Width(22)
 
 func init() {
 	for _, i := range implementation.Implementations {
@@ -41,6 +52,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	log.Printf("successful tests count: %+v", len(result.SuccessfulTests))
-	log.Printf("failed tests count: %+v", len(result.FailedTests))
+	sTests := strconv.Itoa(len(result.SuccessfulTests))
+	fTests := strconv.Itoa(len(result.FailedTests))
+
+	log.Printf("successful tests count: %+v", style.Render(sTests))
+	log.Printf("failed tests count: %+v", style.Render(fTests))
 }

--- a/main.go
+++ b/main.go
@@ -3,30 +3,14 @@ package main
 import (
 	"fmt"
 	"log"
-	"strconv"
 
 	mainApp "graphql-go/compatibility-unit-tests/app"
 	"graphql-go/compatibility-unit-tests/cmd"
 	"graphql-go/compatibility-unit-tests/implementation"
-
-	"github.com/charmbracelet/lipgloss"
+	"graphql-go/compatibility-unit-tests/result"
 )
 
 var choices = []string{}
-
-var successfulStyle = lipgloss.NewStyle().
-	Bold(true).
-	Foreground(lipgloss.Color("#4CAF50")).
-	PaddingTop(0).
-	PaddingLeft(0).
-	Width(40)
-
-var failedStyle = lipgloss.NewStyle().
-	Bold(true).
-	Foreground(lipgloss.Color("#A52A2A")).
-	PaddingTop(0).
-	PaddingLeft(0).
-	Width(40)
 
 func init() {
 	for _, i := range implementation.Implementations {
@@ -50,7 +34,7 @@ func main() {
 	}
 
 	app := mainApp.App{}
-	result, err := app.Run(mainApp.AppParams{
+	r, err := app.Run(mainApp.AppParams{
 		Implementation:    currentImplementation,
 		RefImplementation: implementation.GraphqlJSImplementation,
 	})
@@ -58,9 +42,11 @@ func main() {
 		log.Fatal(err)
 	}
 
-	sTests := strconv.Itoa(len(result.SuccessfulTests))
-	fTests := strconv.Itoa(len(result.FailedTests))
+	summaryParams := &result.SummaryParams{
+		SuccessfulTests: len(r.SuccessfulTests),
+		FailedTests:     len(r.FailedTests),
+	}
+	result := result.Result{}
 
-	fmt.Println(successfulStyle.Render(fmt.Sprintf("successful tests count: %+v", sTests)))
-	fmt.Println(failedStyle.Render(fmt.Sprintf("failed tests count: %+v", fTests)))
+	fmt.Println(result.Summary(summaryParams))
 }

--- a/main.go
+++ b/main.go
@@ -14,13 +14,19 @@ import (
 
 var choices = []string{}
 
-var style = lipgloss.NewStyle().
+var successfulStyle = lipgloss.NewStyle().
 	Bold(true).
-	Foreground(lipgloss.Color("#FAFAFA")).
-	Background(lipgloss.Color("#7D56F4")).
-	PaddingTop(2).
-	PaddingLeft(4).
-	Width(22)
+	Foreground(lipgloss.Color("#4CAF50")).
+	PaddingTop(0).
+	PaddingLeft(0).
+	Width(40)
+
+var failedStyle = lipgloss.NewStyle().
+	Bold(true).
+	Foreground(lipgloss.Color("#A52A2A")).
+	PaddingTop(0).
+	PaddingLeft(0).
+	Width(40)
 
 func init() {
 	for _, i := range implementation.Implementations {
@@ -55,6 +61,6 @@ func main() {
 	sTests := strconv.Itoa(len(result.SuccessfulTests))
 	fTests := strconv.Itoa(len(result.FailedTests))
 
-	log.Printf("successful tests count: %+v", style.Render(sTests))
-	log.Printf("failed tests count: %+v", style.Render(fTests))
+	fmt.Println(successfulStyle.Render(fmt.Sprintf("successful tests count: %+v", sTests)))
+	fmt.Println(failedStyle.Render(fmt.Sprintf("failed tests count: %+v", fTests)))
 }

--- a/result/result.go
+++ b/result/result.go
@@ -33,8 +33,11 @@ func (r *Result) Summary(s *SummaryParams) string {
 	sTests := strconv.Itoa(s.SuccessfulTests)
 	fTests := strconv.Itoa(s.FailedTests)
 
-	successfulResult := successfulStyle.Render(fmt.Sprintf("successful tests count: %+v", sTests))
-	failedResult := failedStyle.Render(fmt.Sprintf("failed tests count: %+v", fTests))
+	successfulSummary := fmt.Sprintf("successful compatible tests count: %+v", sTests)
+	failedSummary := fmt.Sprintf("failed compatible tests count: %+v", fTests)
+
+	successfulResult := successfulStyle.Render(successfulSummary)
+	failedResult := failedStyle.Render(failedSummary)
 
 	return fmt.Sprintf("%s\n%s", successfulResult, failedResult)
 }

--- a/result/result.go
+++ b/result/result.go
@@ -1,0 +1,40 @@
+package result
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+var successfulStyle = lipgloss.NewStyle().
+	Bold(true).
+	Foreground(lipgloss.Color("#4CAF50")).
+	PaddingTop(0).
+	PaddingLeft(0).
+	Width(40)
+
+var failedStyle = lipgloss.NewStyle().
+	Bold(true).
+	Foreground(lipgloss.Color("#A52A2A")).
+	PaddingTop(0).
+	PaddingLeft(0).
+	Width(40)
+
+type SummaryParams struct {
+	SuccessfulTests int
+	FailedTests     int
+}
+
+type Result struct {
+}
+
+func (r *Result) Summary(s *SummaryParams) string {
+	sTests := strconv.Itoa(s.SuccessfulTests)
+	fTests := strconv.Itoa(s.FailedTests)
+
+	successfulResult := successfulStyle.Render(fmt.Sprintf("successful tests count: %+v", sTests))
+	failedResult := failedStyle.Render(fmt.Sprintf("failed tests count: %+v", fTests))
+
+	return fmt.Sprintf("%s\n%s", successfulResult, failedResult)
+}


### PR DESCRIPTION
#### Details
- `result`: improves result summary text.
- `main`: wires Result component.
- `result`: adds Result component.
- `main`: consolidates successful and failed logs styles.
- `main`: adds result initial styling.

#### Test Plan
:heavy_check_mark: Tested that the result component works as expected:
![Screenshot from 2025-03-04 10-22-32](https://github.com/user-attachments/assets/c307b44f-3492-455c-9555-63021c4d6384)
