### PR TITLE
{cmd,main,types,implementation}: adds cli header text support

### DIFF
--- a/bubbletea/bubbletea.go
+++ b/bubbletea/bubbletea.go
@@ -10,6 +10,11 @@ type BubbleTea struct {
 	cursor  int
 	choice  string
 	choices []string
+	ui      UI
+}
+
+type UI struct {
+	header string
 }
 
 func (b BubbleTea) Init() tea.Cmd {
@@ -46,6 +51,7 @@ func (b BubbleTea) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (b BubbleTea) View() string {
 	s := strings.Builder{}
+	s.WriteString(b.ui.header)
 	s.WriteString("")
 
 	for i := 0; i < len(b.choices); i++ {
@@ -68,11 +74,19 @@ type RunResult struct {
 
 type BubbleTeaParams struct {
 	Choices []string
+	UI      BubbleTeaUIParams
+}
+
+type BubbleTeaUIParams struct {
+	Header string
 }
 
 func NewBubbleTea(p *BubbleTeaParams) *BubbleTea {
 	return &BubbleTea{
 		choices: p.Choices,
+		ui: UI{
+			header: p.UI.Header,
+		},
 	}
 }
 

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -16,11 +16,15 @@ type RunResult struct {
 
 type RunParams struct {
 	Choices []string
+	Header  string
 }
 
 func (c *CLI) Run(p *RunParams) (*RunResult, error) {
 	bt := bubbletea.NewBubbleTea(&bubbletea.BubbleTeaParams{
 		Choices: p.Choices,
+		UI: bubbletea.BubbleTeaUIParams{
+			Header: p.Header,
+		},
 	})
 
 	btRunResult, err := bt.Run()

--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -8,7 +8,7 @@ var GraphqlGoImplementation = types.Implementation{
 	Repo: types.Repository{
 		Name:          "graphql-go-graphql",
 		URL:           "https://github.com/graphql-go/graphql",
-		ReferenceName: "refs/heads/master",
+		ReferenceName: "v0.8.1",
 		Dir:           "./repos/graphql-go-graphql/",
 	},
 	Type: types.GoImplementationType,
@@ -27,8 +27,8 @@ var GraphqlJSImplementation = types.Implementation{
 
 var Implementations = []types.Implementation{GraphqlGoImplementation}
 
-var gqlGoImplURL = GraphqlGoImplementation.Repo.URL
-var jsImplURL = GraphqlJSImplementation.Repo.URL
+var gqlGoImplURL = GraphqlGoImplementation.MapKey()
+var jsImplURL = GraphqlJSImplementation.MapKey()
 
 var ImplementationsMap = map[string]types.Implementation{
 	gqlGoImplURL: GraphqlGoImplementation,

--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -4,6 +4,9 @@ import (
 	"graphql-go/compatibility-unit-tests/types"
 )
 
+const ImplementationPrefix = "Implementation"
+const RefImplementationPrefix = "Reference Implementation"
+
 var GraphqlGoImplementation = types.Implementation{
 	Repo: types.Repository{
 		Name:          "graphql-go-graphql",
@@ -29,8 +32,8 @@ var RefImplementation = GraphqlJSImplementation
 
 var Implementations = []types.Implementation{GraphqlGoImplementation}
 
-var gqlGoImplURL = GraphqlGoImplementation.MapKey("Implementation")
-var jsImplURL = GraphqlJSImplementation.MapKey("Implementation")
+var gqlGoImplURL = GraphqlGoImplementation.MapKey(ImplementationPrefix)
+var jsImplURL = GraphqlJSImplementation.MapKey(ImplementationPrefix)
 
 var ImplementationsMap = map[string]types.Implementation{
 	gqlGoImplURL: GraphqlGoImplementation,

--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -25,10 +25,12 @@ var GraphqlJSImplementation = types.Implementation{
 	TestNamesFilePath: "./puller-js/unit-tests.txt",
 }
 
+var RefImplementation = GraphqlJSImplementation
+
 var Implementations = []types.Implementation{GraphqlGoImplementation}
 
-var gqlGoImplURL = GraphqlGoImplementation.MapKey()
-var jsImplURL = GraphqlJSImplementation.MapKey()
+var gqlGoImplURL = GraphqlGoImplementation.MapKey("Implementation")
+var jsImplURL = GraphqlJSImplementation.MapKey("Implementation")
 
 var ImplementationsMap = map[string]types.Implementation{
 	gqlGoImplURL: GraphqlGoImplementation,

--- a/main.go
+++ b/main.go
@@ -14,15 +14,18 @@ var choices = []string{}
 
 func init() {
 	for _, i := range implementation.Implementations {
-		choices = append(choices, i.Repo.String())
+		choices = append(choices, i.Repo.String("Implementation"))
 	}
 }
 
 func main() {
 	cli := cmd.CLI{}
 
+	header := implementation.RefImplementation.Repo.String("Reference Implementation")
+
 	cliResult, err := cli.Run(&cmd.RunParams{
 		Choices: choices,
+		Header:  header,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -14,14 +14,14 @@ var choices = []string{}
 
 func init() {
 	for _, i := range implementation.Implementations {
-		choices = append(choices, i.Repo.String("Implementation"))
+		choices = append(choices, i.Repo.String(implementation.ImplementationPrefix))
 	}
 }
 
 func main() {
 	cli := cmd.CLI{}
 
-	header := implementation.RefImplementation.Repo.String("Reference Implementation")
+	header := implementation.RefImplementation.Repo.String(implementation.RefImplementationPrefix)
 
 	cliResult, err := cli.Run(&cmd.RunParams{
 		Choices: choices,

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ var choices = []string{}
 
 func init() {
 	for _, i := range implementation.Implementations {
-		choices = append(choices, i.Repo.URL)
+		choices = append(choices, i.Repo.String())
 	}
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -19,7 +19,8 @@ type Repository struct {
 }
 
 func (r *Repository) String() string {
-	return fmt.Sprintf(taggedRepoURL, r.URL, r.ReferenceName)
+	base := fmt.Sprintf("Implementation: %s\n", taggedRepoURL)
+	return fmt.Sprintf(base, r.URL, r.ReferenceName)
 }
 
 type Implementation struct {

--- a/types/types.go
+++ b/types/types.go
@@ -1,5 +1,9 @@
 package types
 
+import "fmt"
+
+const taggedRepoURL string = "%s/releases/tag/%s"
+
 type ImplementationType uint
 
 const (
@@ -14,11 +18,19 @@ type Repository struct {
 	Dir           string
 }
 
+func (r *Repository) String() string {
+	return fmt.Sprintf(taggedRepoURL, r.URL, r.ReferenceName)
+}
+
 type Implementation struct {
 	Repo              Repository
 	Type              ImplementationType
 	TestNames         []string
 	TestNamesFilePath string
+}
+
+func (i *Implementation) MapKey() string {
+	return i.Repo.String()
 }
 
 type ImplementationTest struct {

--- a/types/types.go
+++ b/types/types.go
@@ -18,8 +18,8 @@ type Repository struct {
 	Dir           string
 }
 
-func (r *Repository) String() string {
-	base := fmt.Sprintf("Implementation: %s\n", taggedRepoURL)
+func (r *Repository) String(prefix string) string {
+	base := fmt.Sprintf("%s: %s\n", prefix, taggedRepoURL)
 	return fmt.Sprintf(base, r.URL, r.ReferenceName)
 }
 
@@ -30,8 +30,8 @@ type Implementation struct {
 	TestNamesFilePath string
 }
 
-func (i *Implementation) MapKey() string {
-	return i.Repo.String()
+func (i *Implementation) MapKey(prefix string) string {
+	return i.Repo.String(prefix)
 }
 
 type ImplementationTest struct {


### PR DESCRIPTION
#### Details
- `main`: wires ref implementation header to cli.
- `cmd`: wires bubbletea header params.
- `types`: wire prefix to repo string method.
- `implementation`: adds RefImplementation var and wires prefixes.
- `bubbletea`: adds header ui support.
- `types`: updates Repository string method.
- `main`: wires Repo string method.
- `implementation`: consolidates repo ref and map keys.
- `types`: consolidates types methods.
- `main`: parameterized implementation prefixes.
- `implementation`: adding prefixes.

#### Test Plan
:heavy_check_mark: Tested that the header text cli support works as expected:

```
$ ./bin/start.sh 
Reference Implementation: https://github.com/graphql/graphql-js/releases/tag/v0.6.0
(•) Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1


(press q to quit)
Enumerating objects: 5158, done.
Counting objects: 100% (79/79), done.
Compressing objects: 100% (50/50), done.
Total 5158 (delta 49), reused 29 (delta 29), pack-reused 5079 (from 4)
successful compatible tests count: 28   
failed compatible tests count: 847
```